### PR TITLE
refactor: fix clippy warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,10 +27,10 @@ pub fn get_os_name() -> Result<String, Box<dyn Error>> {
             for line in file_contents.lines() {
                 if line.contains(search_string) {
                     // Get the value for the key, `PRETTY_NAME`
-                    let vec_new = line.split("=").last().unwrap();
+                    let vec_new = line.split('=').last().unwrap();
                     // Remove the '"' , i.e. double quotes from the output.
                     let vec_new = vec_new.replace('"', "");
-                    return Ok(vec_new.to_string());
+                    return Ok(vec_new);
                 }
             }
             String::from("Unknown")
@@ -38,7 +38,7 @@ pub fn get_os_name() -> Result<String, Box<dyn Error>> {
     };
     // Remove the '"' , i.e. double quotes from the output.
     let os_name = os_name.replace('"', "");
-    let os_name = os_name.replace("\n", ""); // Remove any newline character
+    let os_name = os_name.replace('\n', ""); // Remove any newline character
 
     Ok(os_name)
 }
@@ -56,7 +56,7 @@ pub fn get_kernel_version() -> String {
             // Split the string based on `-`, and then reverse it again,
             // to obtain only the kernel version, and not any other info.
             let rev_kernel_ver = rev_kernel_ver
-                .split("-")
+                .split('-')
                 .last()
                 .unwrap()
                 .chars()
@@ -78,9 +78,9 @@ pub fn get_shell_name() -> String {
     let shell_var = "SHELL";
     match env::var(shell_var) {
         Ok(mut val) => {
-            val = val.replace("/", " "); // Replace all the forward slashes
+            val = val.replace('/', " "); // Replace all the forward slashes
                                          // with a space.
-            val.split(" ").last().unwrap().to_string() // Split the string
+            val.split(' ').last().unwrap().to_string() // Split the string
                                                        // based on the spaces
                                                        // and get the last word.
         }
@@ -120,7 +120,8 @@ pub fn get_sys_uptime() -> String {
 
     let up_time = match up_time {
         Ok(x) => {
-            let time = String::from_utf8(x.stdout)
+             // Remove the word up.
+            String::from_utf8(x.stdout)
                 .unwrap()
                 .replace("hours", "h") // Replace words with letters.
                 .replace("hour", "h")
@@ -128,14 +129,13 @@ pub fn get_sys_uptime() -> String {
                 .replace("minute", "m")
                 .replace("days", "d")
                 .replace("day", "d")
-                .replace("up ", ""); // Remove the word up.
-            time
+                .replace("up ", "")
         }
         Err(_) => "Unknown".to_string(), // If the commnd fails, assingn
                                          // up_time to "Unknown".
     };
 
-    let up_time = up_time.replace("\n", ""); // Remove any newline character
+     // Remove any newline character
 
-    up_time
+    up_time.replace('\n', "")
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use clap::Parser;
 
 // Bring the functions from `lib.rs`, and 
 // `packages.rs` into scope.
-use fetchit;
+
 pub mod packages;
 
 
@@ -76,7 +76,7 @@ fn main() {
     
     // Update the ascii art if a file was passed, but
     // a check for the required length is also done.
-    if custom_ascii_string != "Unknown".to_string() {
+    if custom_ascii_string != *"Unknown" {
         let mut ascii_lines = 0;
         for _ in custom_ascii_string.lines() {
             ascii_lines += 1;            
@@ -205,12 +205,12 @@ fn main() {
         }
     }
 
-    let mut box_side = format!("│");
-    let mut box_top = format!("─").repeat(final_length);
-    let mut box_top_left_corner = format!("╭");
-    let mut box_top_right_corner = format!("╮");
-    let mut box_bottom_left_corner = format!("╰");
-    let mut box_bottom_right_corner = format!("╯");
+    let mut box_side = "│".to_string();
+    let mut box_top = "─".to_string().repeat(final_length);
+    let mut box_top_left_corner = "╭".to_string();
+    let mut box_top_right_corner = "╮".to_string();
+    let mut box_bottom_left_corner = "╰".to_string();
+    let mut box_bottom_right_corner = "╯".to_string();
 
     match args.outer_box_color {
         Some(x) => {
@@ -289,17 +289,17 @@ fn main() {
     // printed, and this text contains 14 characters. The `11` and `5` above
     // are chosen based on that formatting.
 
-    println!("");
+    println!();
     println!("{} {}{}{}", ascii_vec[0], box_top_left_corner, box_top, box_top_right_corner);
-    println!("{} {} {}        {}  {}{}{}", ascii_vec[1], box_side, format!("OS").red().bold().italic(), format!("").red(), os_name, format!(" ").repeat(final_length - 14 - string_length_vector[0]), box_side);
-    println!("{} {} {}    {}  {}{}{}", ascii_vec[2], box_side, format!("KERNEL").magenta().bold().italic(), format!("").magenta(), kernel, format!(" ").repeat(final_length - 14 - string_length_vector[1]), box_side);
-    println!("{} {} {}     {}  {}{}{}", ascii_vec[3], box_side, format!("SHELL").yellow().bold().italic(), format!("").yellow(), shell_name, format!(" ").repeat(final_length - 14 - string_length_vector[2]), box_side);
-    println!("{} {} {}   {}  {}{}{}", ascii_vec[4], box_side, format!("SESSION").blue().bold().italic(), format!("").blue(), session, format!(" ").repeat(final_length - 14 - string_length_vector[3]), box_side);
-    println!("{} {} {}    {} {}{}{}", ascii_vec[5], box_side, format!("UPTIME").cyan().bold().italic(), format!("祥").cyan(), uptime, format!(" ").repeat(final_length - 14 - string_length_vector[4]), box_side);
-    println!("{} {} {}  {}  {}{}{}", ascii_vec[6], box_side, format!("PACKAGES").green().bold().italic(), format!("").green(), total_packages, format!(" ").repeat(final_length - 14 - string_length_vector[5]), box_side);
+    println!("{} {} {}        {}  {}{}{}", ascii_vec[1], box_side, "OS".to_string().red().bold().italic(), "".to_string().red(), os_name, " ".to_string().repeat(final_length - 14 - string_length_vector[0]), box_side);
+    println!("{} {} {}    {}  {}{}{}", ascii_vec[2], box_side, "KERNEL".to_string().magenta().bold().italic(), "".to_string().magenta(), kernel, " ".to_string().repeat(final_length - 14 - string_length_vector[1]), box_side);
+    println!("{} {} {}     {}  {}{}{}", ascii_vec[3], box_side, "SHELL".to_string().yellow().bold().italic(), "".to_string().yellow(), shell_name, " ".to_string().repeat(final_length - 14 - string_length_vector[2]), box_side);
+    println!("{} {} {}   {}  {}{}{}", ascii_vec[4], box_side, "SESSION".to_string().blue().bold().italic(), "".to_string().blue(), session, " ".to_string().repeat(final_length - 14 - string_length_vector[3]), box_side);
+    println!("{} {} {}    {} {}{}{}", ascii_vec[5], box_side, "UPTIME".to_string().cyan().bold().italic(), "祥".to_string().cyan(), uptime, " ".to_string().repeat(final_length - 14 - string_length_vector[4]), box_side);
+    println!("{} {} {}  {}  {}{}{}", ascii_vec[6], box_side, "PACKAGES".to_string().green().bold().italic(), "".to_string().green(), total_packages, " ".to_string().repeat(final_length - 14 - string_length_vector[5]), box_side);
     println!("{} {}{}{}", ascii_vec[7], box_bottom_left_corner, box_top, box_bottom_right_corner);
     println!("{} ", ascii_vec[8]);
-    println!("");
+    println!();
 }
 
 #[derive(Debug, Parser)]

--- a/src/packages.rs
+++ b/src/packages.rs
@@ -96,7 +96,7 @@ pub fn packages_generic(cmd: &str, options: Vec<&str>) -> Result<String, String>
     // if so, unwrap the output from stdout, and return it.
     match packages {
         Ok(x) => Ok(String::from_utf8(x.stdout).unwrap()),
-        Err(e) => return Err(e.to_string()),
+        Err(e) => Err(e.to_string()),
     }
 }
 
@@ -161,7 +161,7 @@ pub fn packges_fedora_based() -> Result<String, String> {
             let packages = Command::new("dnf").args(["list", "installed"]).output();
             match packages {
                 Ok(x) => Ok(String::from_utf8(x.stdout).unwrap()),
-                Err(e) => return Err(e.to_string()),
+                Err(e) => Err(e.to_string()),
             }
         }
     }
@@ -188,9 +188,9 @@ pub fn packages_nixos_based() -> Result<String, String> {
                     let prev_output = String::from_utf8(y.stdout).unwrap();
                     Ok(format!("{}{}", packages_output, prev_output))
                 }
-                Err(e) => return Err(e.to_string()),
+                Err(e) => Err(e.to_string()),
             }
         }
-        Err(e) => return Err(e.to_string()),
+        Err(e) => Err(e.to_string()),
     }
 }


### PR DESCRIPTION
I ran `cargo clippy --fix` to fix some linting errors. If you want try it out on the current commit and see what it shows you as output. Make sure to use `cargo clippy` to get the errors printed to the console. Since you seem to be new to Rust it might be a good idea!